### PR TITLE
Replace calls to TestCase::assertEqualsCanonicalizing()

### DIFF
--- a/tests/Functional/Controller/SourcesControllerTest.php
+++ b/tests/Functional/Controller/SourcesControllerTest.php
@@ -133,7 +133,7 @@ class SourcesControllerTest extends WebTestCase
         \assert($source instanceof SourceInterface);
         $expected['id'] = $source->getId();
 
-        self::assertEqualsCanonicalizing($expected, json_decode((string) $response->getContent(), true));
+        self::assertEquals($expected, json_decode((string) $response->getContent(), true));
     }
 
     /**

--- a/tests/Functional/Services/SourceFactoryTest.php
+++ b/tests/Functional/Services/SourceFactoryTest.php
@@ -254,7 +254,7 @@ class SourceFactoryTest extends WebTestCase
         $this->assertCreatedSource($source, $expectedUserId);
 
         self::assertEquals($expectedParent, $source->getParent());
-        self::assertEqualsCanonicalizing($expectedParameters, $source->getParameters());
+        self::assertEquals($expectedParameters, $source->getParameters());
     }
 
     private function assertCreatedSource(SourceInterface $source, string $expectedUserId): void


### PR DESCRIPTION
Fixes #74