### PR TITLE
GitRepositoryCloner::clone() path is a string

### DIFF
--- a/src/Services/GitRepositoryCloner.php
+++ b/src/Services/GitRepositoryCloner.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Exception\ProcessExecutorException;
-use App\Model\AbsoluteFileLocator;
 use App\Model\CommandDefinition\Definition;
 use App\Model\CommandDefinition\Option;
 use App\Model\ProcessOutput;
@@ -21,7 +20,7 @@ class GitRepositoryCloner
     /**
      * @throws ProcessExecutorException
      */
-    public function clone(string $url, AbsoluteFileLocator $path): ProcessOutput
+    public function clone(string $url, string $path): ProcessOutput
     {
         return $this->processExecutor->execute(
             (new Definition('git clone'))

--- a/tests/Unit/Services/GitRepositoryClonerTest.php
+++ b/tests/Unit/Services/GitRepositoryClonerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Services;
 
-use App\Model\AbsoluteFileLocator;
 use App\Model\CommandDefinition\Definition;
 use App\Model\CommandDefinition\Option;
 use App\Model\EntityId;
@@ -37,7 +36,7 @@ class GitRepositoryClonerTest extends WebTestCase
 
         self::assertEquals(
             $executorProcessOutput,
-            $gitRepositoryCloner->clone($url, new AbsoluteFileLocator($path))
+            $gitRepositoryCloner->clone($url, $path)
         );
     }
 }


### PR DESCRIPTION
Fixes #205