### PR TITLE
SerializedSuite::setPreparationFailed() does not mutate existing failure data

### DIFF
--- a/src/Entity/SerializedSuite.php
+++ b/src/Entity/SerializedSuite.php
@@ -80,13 +80,13 @@ class SerializedSuite implements UserHeldEntityInterface, DirectoryLocatorInterf
         return $this->suite->getUserId();
     }
 
-    public function setPreparationFailed(
-        FailureReason $failureReason,
-        string $failureMessage
-    ): self {
-        $this->state = State::FAILED;
-        $this->failureReason = $failureReason;
-        $this->failureMessage = $failureMessage;
+    public function setPreparationFailed(FailureReason $failureReason, string $failureMessage): self
+    {
+        if (State::FAILED !== $this->state) {
+            $this->state = State::FAILED;
+            $this->failureReason = $failureReason;
+            $this->failureMessage = $failureMessage;
+        }
 
         return $this;
     }

--- a/tests/Unit/Entity/SerializedSuiteTest.php
+++ b/tests/Unit/Entity/SerializedSuiteTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\SerializedSuite;
+use App\Entity\Suite;
+use App\Enum\SerializedSuite\FailureReason;
+use App\Enum\SerializedSuite\State;
+use PHPUnit\Framework\TestCase;
+
+class SerializedSuiteTest extends TestCase
+{
+    public function testSetPreparationFailedIsIdempotent(): void
+    {
+        $serializedSuite = new SerializedSuite(
+            md5((string) rand()),
+            new Suite(md5((string) rand())),
+            []
+        );
+
+        self::assertSame(State::REQUESTED, $serializedSuite->getState());
+
+        $serializedSuiteData = $serializedSuite->jsonSerialize();
+        self::assertArrayNotHasKey('failure_reason', $serializedSuiteData);
+        self::assertArrayNotHasKey('failure_message', $serializedSuiteData);
+
+        $failureReason = FailureReason::GIT_CHECKOUT;
+        $failureMessage = md5((string) rand());
+
+        $serializedSuite->setPreparationFailed($failureReason, $failureMessage);
+
+        self::assertSame(State::FAILED, $serializedSuite->getState());
+        $serializedSuiteData = $serializedSuite->jsonSerialize();
+        self::assertSame($failureReason->value, $serializedSuiteData['failure_reason'] ?? null);
+        self::assertSame($failureMessage, $serializedSuiteData['failure_message'] ?? null);
+
+        $serializedSuite->setPreparationFailed(FailureReason::GIT_CLONE, $failureMessage);
+
+        self::assertSame(State::FAILED, $serializedSuite->getState());
+        $serializedSuiteData = $serializedSuite->jsonSerialize();
+        self::assertSame($failureReason->value, $serializedSuiteData['failure_reason'] ?? null);
+        self::assertSame($failureMessage, $serializedSuiteData['failure_message'] ?? null);
+    }
+}


### PR DESCRIPTION
Fixes #1095