### PR TITLE
SourceInterface::getRunParameterNames() returns non-empty-string[]

### DIFF
--- a/src/Entity/SourceInterface.php
+++ b/src/Entity/SourceInterface.php
@@ -18,7 +18,7 @@ interface SourceInterface extends UserHeldEntityInterface
     public function getDeletedAt(): ?\DateTimeImmutable;
 
     /**
-     * @return string[]
+     * @return non-empty-string[]
      */
     public function getRunParameterNames(): array;
 


### PR DESCRIPTION
Fixes #1127