### PR TITLE
EntityStorageException::getType() returns null if no type is defined

### DIFF
--- a/src/Exception/EntityStorageException.php
+++ b/src/Exception/EntityStorageException.php
@@ -33,15 +33,15 @@ class EntityStorageException extends \Exception implements Error, HasHttpCode, S
     }
 
     /**
-     * @return non-empty-string
+     * @return ?non-empty-string
      */
-    public function getType(): string
+    public function getType(): ?string
     {
-        $operationType = 'unknown';
+        $operationType = null;
         if ($this->filesystemException instanceof FilesystemOperationFailed) {
             $operationType = strtolower($this->filesystemException->operation());
             if ('' === $operationType) {
-                $operationType = 'unknown';
+                $operationType = null;
             }
         }
 

--- a/tests/Functional/FilesystemExceptionHandling/FilesystemExceptionHandlingTest.php
+++ b/tests/Functional/FilesystemExceptionHandling/FilesystemExceptionHandlingTest.php
@@ -322,7 +322,6 @@ class FilesystemExceptionHandlingTest extends WebTestCase
                             'id' => $entity->getId(),
                             'type' => $entity->getEntityType()->value,
                         ],
-                        'type' => 'unknown',
                     ];
                 },
             ],


### PR DESCRIPTION
Fixes #1303